### PR TITLE
Fix conference number

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 ---
-booktitle: Proceedings of The 8th Conference on Robot Learning
+booktitle: Proceedings of The 9th Conference on Robot Learning
 shortname: CoRL
 year: '2025'
 volume: '305'
@@ -29,7 +29,7 @@ editor:
   family: Park
 title: Proceedings of Machine Learning Research
 description: |
-  Proceedings of The 8th Conference on Robot Learning
+  Proceedings of The 9th Conference on Robot Learning
     Held in Seoul, Korea on 27-30 September 2025
 
   Published as Volume 305 by the Proceedings of Machine Learning Research on 07 October 2025.

--- a/_posts/2025-10-07-agia25a.md
+++ b/_posts/2025-10-07-agia25a.md
@@ -52,7 +52,7 @@ author:
   family: Bohg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ai25a.md
+++ b/_posts/2025-10-07-ai25a.md
@@ -55,7 +55,7 @@ author:
   family: Su
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-akcin25a.md
+++ b/_posts/2025-10-07-akcin25a.md
@@ -46,7 +46,7 @@ author:
   family: Chinchali
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-allshire25a.md
+++ b/_posts/2025-10-07-allshire25a.md
@@ -52,7 +52,7 @@ author:
   family: Kanazawa
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-almuzairee25a.md
+++ b/_posts/2025-10-07-almuzairee25a.md
@@ -38,7 +38,7 @@ author:
   family: Christensen
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-amigo25a.md
+++ b/_posts/2025-10-07-amigo25a.md
@@ -46,7 +46,7 @@ author:
   family: Righetti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-amir25a.md
+++ b/_posts/2025-10-07-amir25a.md
@@ -50,7 +50,7 @@ author:
   family: Prorok
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-anwar25a.md
+++ b/_posts/2025-10-07-anwar25a.md
@@ -47,7 +47,7 @@ author:
   family: Thomason
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-aoyama25a.md
+++ b/_posts/2025-10-07-aoyama25a.md
@@ -44,7 +44,7 @@ author:
   family: Vijayakumar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-arachchige25a.md
+++ b/_posts/2025-10-07-arachchige25a.md
@@ -59,7 +59,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-arslanoglu25a.md
+++ b/_posts/2025-10-07-arslanoglu25a.md
@@ -46,7 +46,7 @@ author:
   family: Leibe
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-atreya25a.md
+++ b/_posts/2025-10-07-atreya25a.md
@@ -95,7 +95,7 @@ author:
   family: Levine
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-bendikas25a.md
+++ b/_posts/2025-10-07-bendikas25a.md
@@ -43,7 +43,7 @@ author:
   family: Mazzaglia
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-bharadhwaj25a.md
+++ b/_posts/2025-10-07-bharadhwaj25a.md
@@ -56,7 +56,7 @@ author:
   family: Kirmani
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-black25a.md
+++ b/_posts/2025-10-07-black25a.md
@@ -110,7 +110,7 @@ author:
   family: Zhilinsky
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-boyle25a.md
+++ b/_posts/2025-10-07-boyle25a.md
@@ -51,7 +51,7 @@ author:
   family: Benini
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-cao25a.md
+++ b/_posts/2025-10-07-cao25a.md
@@ -66,7 +66,7 @@ author:
   family: Chitta
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-carlotti25a.md
+++ b/_posts/2025-10-07-carlotti25a.md
@@ -41,7 +41,7 @@ author:
   family: Giusti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-cathomen25a.md
+++ b/_posts/2025-10-07-cathomen25a.md
@@ -46,7 +46,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chahine25a.md
+++ b/_posts/2025-10-07-chahine25a.md
@@ -41,7 +41,7 @@ author:
   family: Rus
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chandaka25a.md
+++ b/_posts/2025-10-07-chandaka25a.md
@@ -43,7 +43,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chandra25a.md
+++ b/_posts/2025-10-07-chandra25a.md
@@ -49,7 +49,7 @@ author:
   family: Valada
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chen25a.md
+++ b/_posts/2025-10-07-chen25a.md
@@ -51,7 +51,7 @@ author:
   family: Levine
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chen25b.md
+++ b/_posts/2025-10-07-chen25b.md
@@ -57,7 +57,7 @@ author:
   family: Dong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chen25c.md
+++ b/_posts/2025-10-07-chen25c.md
@@ -51,7 +51,7 @@ author:
   family: Tomizuka
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chen25d.md
+++ b/_posts/2025-10-07-chen25d.md
@@ -43,7 +43,7 @@ author:
   family: Driggs-Campbell
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-chen25e.md
+++ b/_posts/2025-10-07-chen25e.md
@@ -45,7 +45,7 @@ author:
   family: Liu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-cheng25a.md
+++ b/_posts/2025-10-07-cheng25a.md
@@ -51,7 +51,7 @@ author:
   family: Sartoretti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-clark25a.md
+++ b/_posts/2025-10-07-clark25a.md
@@ -52,7 +52,7 @@ author:
   family: Belkhale
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-curtis25a.md
+++ b/_posts/2025-10-07-curtis25a.md
@@ -46,7 +46,7 @@ author:
   family: Kaelbling
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-dai25a.md
+++ b/_posts/2025-10-07-dai25a.md
@@ -51,7 +51,7 @@ author:
   family: Chai
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-dan25a.md
+++ b/_posts/2025-10-07-dan25a.md
@@ -49,7 +49,7 @@ author:
   family: Choudhury
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-deng25a.md
+++ b/_posts/2025-10-07-deng25a.md
@@ -64,7 +64,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-deng25b.md
+++ b/_posts/2025-10-07-deng25b.md
@@ -54,7 +54,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-deng25c.md
+++ b/_posts/2025-10-07-deng25c.md
@@ -49,7 +49,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-derajic25a.md
+++ b/_posts/2025-10-07-derajic25a.md
@@ -43,7 +43,7 @@ author:
   family: Hönig
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-deshpande25a.md
+++ b/_posts/2025-10-07-deshpande25a.md
@@ -53,7 +53,7 @@ author:
   family: Krishna
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ding25a.md
+++ b/_posts/2025-10-07-ding25a.md
@@ -39,7 +39,7 @@ author:
   family: Fitzgerald
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-dong25a.md
+++ b/_posts/2025-10-07-dong25a.md
@@ -48,7 +48,7 @@ author:
   family: Everett
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-fan25a.md
+++ b/_posts/2025-10-07-fan25a.md
@@ -63,7 +63,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-fang25a.md
+++ b/_posts/2025-10-07-fang25a.md
@@ -65,7 +65,7 @@ author:
   family: Fang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-fele25a.md
+++ b/_posts/2025-10-07-fele25a.md
@@ -35,7 +35,7 @@ author:
   family: Babic
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-feng25a.md
+++ b/_posts/2025-10-07-feng25a.md
@@ -50,7 +50,7 @@ author:
   family: Knoll
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-feng25b.md
+++ b/_posts/2025-10-07-feng25b.md
@@ -48,7 +48,7 @@ author:
   family: Luo
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-field25a.md
+++ b/_posts/2025-10-07-field25a.md
@@ -44,7 +44,7 @@ author:
   family: Lepora
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-freud25a.md
+++ b/_posts/2025-10-07-freud25a.md
@@ -40,7 +40,7 @@ author:
   family: Lepora
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-fu25a.md
+++ b/_posts/2025-10-07-fu25a.md
@@ -50,7 +50,7 @@ author:
   family: Ravichandar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-fu25b.md
+++ b/_posts/2025-10-07-fu25b.md
@@ -48,7 +48,7 @@ author:
   family: Gao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ganai25a.md
+++ b/_posts/2025-10-07-ganai25a.md
@@ -48,7 +48,7 @@ author:
   family: Pavone
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-garg25a.md
+++ b/_posts/2025-10-07-garg25a.md
@@ -56,7 +56,7 @@ author:
   family: Reid
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-geng25a.md
+++ b/_posts/2025-10-07-geng25a.md
@@ -55,7 +55,7 @@ author:
   family: Zhao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-gill25a.md
+++ b/_posts/2025-10-07-gill25a.md
@@ -31,7 +31,7 @@ author:
   family: Constantinescu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ginting25a.md
+++ b/_posts/2025-10-07-ginting25a.md
@@ -71,7 +71,7 @@ author:
   family: Omidshafiei
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-goel25a.md
+++ b/_posts/2025-10-07-goel25a.md
@@ -53,7 +53,7 @@ author:
   family: Erickson
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-goshen25a.md
+++ b/_posts/2025-10-07-goshen25a.md
@@ -33,7 +33,7 @@ author:
   family: Keren
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-grillotti25a.md
+++ b/_posts/2025-10-07-grillotti25a.md
@@ -47,7 +47,7 @@ author:
   family: Cully
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-guo25a.md
+++ b/_posts/2025-10-07-guo25a.md
@@ -44,7 +44,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-gupta25a.md
+++ b/_posts/2025-10-07-gupta25a.md
@@ -49,7 +49,7 @@ author:
   family: Bajcsy
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-gurumurthy25a.md
+++ b/_posts/2025-10-07-gurumurthy25a.md
@@ -44,7 +44,7 @@ author:
   family: Manchester
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-haldar25a.md
+++ b/_posts/2025-10-07-haldar25a.md
@@ -39,7 +39,7 @@ author:
   family: Pinto
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-han25a.md
+++ b/_posts/2025-10-07-han25a.md
@@ -59,7 +59,7 @@ author:
   family: Boots
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hao25a.md
+++ b/_posts/2025-10-07-hao25a.md
@@ -37,7 +37,7 @@ author:
   family: Soh
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hao25b.md
+++ b/_posts/2025-10-07-hao25b.md
@@ -47,7 +47,7 @@ author:
   family: Erickson
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-haon25a.md
+++ b/_posts/2025-10-07-haon25a.md
@@ -46,7 +46,7 @@ author:
   family: Tomlin
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hassidof25a.md
+++ b/_posts/2025-10-07-hassidof25a.md
@@ -42,7 +42,7 @@ author:
   family: Solovey
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-he25a.md
+++ b/_posts/2025-10-07-he25a.md
@@ -57,7 +57,7 @@ author:
   family: Sartoretti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-higuera25a.md
+++ b/_posts/2025-10-07-higuera25a.md
@@ -57,7 +57,7 @@ author:
   family: Mukadam
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hu25a.md
+++ b/_posts/2025-10-07-hu25a.md
@@ -48,7 +48,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hu25b.md
+++ b/_posts/2025-10-07-hu25b.md
@@ -43,7 +43,7 @@ author:
   family: Martín-Martín
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hu25c.md
+++ b/_posts/2025-10-07-hu25c.md
@@ -59,7 +59,7 @@ author:
   family: Biswas
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hu25d.md
+++ b/_posts/2025-10-07-hu25d.md
@@ -45,7 +45,7 @@ author:
   family: Qian
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-hu25e.md
+++ b/_posts/2025-10-07-hu25e.md
@@ -59,7 +59,7 @@ author:
   family: Liu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-huang25a.md
+++ b/_posts/2025-10-07-huang25a.md
@@ -48,7 +48,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-huang25b.md
+++ b/_posts/2025-10-07-huang25b.md
@@ -60,7 +60,7 @@ author:
   family: Li
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-huang25c.md
+++ b/_posts/2025-10-07-huang25c.md
@@ -49,7 +49,7 @@ author:
   family: Schwager
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-huang25d.md
+++ b/_posts/2025-10-07-huang25d.md
@@ -43,7 +43,7 @@ author:
   family: Hermans
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jaeger25a.md
+++ b/_posts/2025-10-07-jaeger25a.md
@@ -50,7 +50,7 @@ author:
   family: Geiger
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jain25a.md
+++ b/_posts/2025-10-07-jain25a.md
@@ -49,7 +49,7 @@ author:
   family: Ravichandar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jain25b.md
+++ b/_posts/2025-10-07-jain25b.md
@@ -45,7 +45,7 @@ author:
   family: Paul
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jang25a.md
+++ b/_posts/2025-10-07-jang25a.md
@@ -95,7 +95,7 @@ author:
   family: Fan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jaszczuk25a.md
+++ b/_posts/2025-10-07-jaszczuk25a.md
@@ -41,7 +41,7 @@ author:
   family: Figueroa
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jiang25a.md
+++ b/_posts/2025-10-07-jiang25a.md
@@ -49,7 +49,7 @@ author:
   family: Ancha
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jiang25b.md
+++ b/_posts/2025-10-07-jiang25b.md
@@ -58,7 +58,7 @@ author:
   family: Fei-Fei
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jiang25c.md
+++ b/_posts/2025-10-07-jiang25c.md
@@ -60,7 +60,7 @@ author:
   family: Lioutikov
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jiang25d.md
+++ b/_posts/2025-10-07-jiang25d.md
@@ -50,7 +50,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jung25a.md
+++ b/_posts/2025-10-07-jung25a.md
@@ -44,7 +44,7 @@ author:
   family: Kim
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jung25b.md
+++ b/_posts/2025-10-07-jung25b.md
@@ -48,7 +48,7 @@ author:
   family: Hays
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jung25c.md
+++ b/_posts/2025-10-07-jung25c.md
@@ -42,7 +42,7 @@ author:
   family: Kim
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jung25d.md
+++ b/_posts/2025-10-07-jung25d.md
@@ -47,7 +47,7 @@ author:
   family: Kousik
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-jung25e.md
+++ b/_posts/2025-10-07-jung25e.md
@@ -37,7 +37,7 @@ author:
   family: Kim
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kang25a.md
+++ b/_posts/2025-10-07-kang25a.md
@@ -45,7 +45,7 @@ author:
   family: Park
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kang25b.md
+++ b/_posts/2025-10-07-kang25b.md
@@ -47,7 +47,7 @@ author:
   family: Cremers
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-katsumata25a.md
+++ b/_posts/2025-10-07-katsumata25a.md
@@ -45,7 +45,7 @@ author:
   family: Sugiura
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kerr25a.md
+++ b/_posts/2025-10-07-kerr25a.md
@@ -51,7 +51,7 @@ author:
   family: Kanazawa
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kim25a.md
+++ b/_posts/2025-10-07-kim25a.md
@@ -43,7 +43,7 @@ author:
   family: Park
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kim25b.md
+++ b/_posts/2025-10-07-kim25b.md
@@ -43,7 +43,7 @@ author:
   family: Ohn-Bar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kim25c.md
+++ b/_posts/2025-10-07-kim25c.md
@@ -50,7 +50,7 @@ author:
   family: Nam
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kim25d.md
+++ b/_posts/2025-10-07-kim25d.md
@@ -43,7 +43,7 @@ author:
   family: Lee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kim25e.md
+++ b/_posts/2025-10-07-kim25e.md
@@ -46,7 +46,7 @@ author:
   family: Hong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kit25a.md
+++ b/_posts/2025-10-07-kit25a.md
@@ -59,7 +59,7 @@ author:
   family: Ren
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kumar25a.md
+++ b/_posts/2025-10-07-kumar25a.md
@@ -53,7 +53,7 @@ author:
   family: Martín-Martín
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-kwok25a.md
+++ b/_posts/2025-10-07-kwok25a.md
@@ -59,7 +59,7 @@ author:
   family: Pavone
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lee25a.md
+++ b/_posts/2025-10-07-lee25a.md
@@ -43,7 +43,7 @@ author:
   family: Kuo
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lee25b.md
+++ b/_posts/2025-10-07-lee25b.md
@@ -49,7 +49,7 @@ author:
   family: Huang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lepert25a.md
+++ b/_posts/2025-10-07-lepert25a.md
@@ -37,7 +37,7 @@ author:
   family: Bohg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25a.md
+++ b/_posts/2025-10-07-li25a.md
@@ -56,7 +56,7 @@ author:
   family: Pan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25b.md
+++ b/_posts/2025-10-07-li25b.md
@@ -44,7 +44,7 @@ author:
   family: Pollefeys
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25c.md
+++ b/_posts/2025-10-07-li25c.md
@@ -60,7 +60,7 @@ author:
   family: Huang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25d.md
+++ b/_posts/2025-10-07-li25d.md
@@ -53,7 +53,7 @@ author:
   family: Chalvatzaki
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25e.md
+++ b/_posts/2025-10-07-li25e.md
@@ -46,7 +46,7 @@ author:
   family: Held
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25f.md
+++ b/_posts/2025-10-07-li25f.md
@@ -49,7 +49,7 @@ author:
   family: Hsieh
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25g.md
+++ b/_posts/2025-10-07-li25g.md
@@ -65,7 +65,7 @@ author:
   family: Dong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25h.md
+++ b/_posts/2025-10-07-li25h.md
@@ -51,7 +51,7 @@ author:
   family: Huang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-li25i.md
+++ b/_posts/2025-10-07-li25i.md
@@ -52,7 +52,7 @@ author:
   family: Shi
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lin25a.md
+++ b/_posts/2025-10-07-lin25a.md
@@ -60,7 +60,7 @@ author:
   family: Zhao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lin25b.md
+++ b/_posts/2025-10-07-lin25b.md
@@ -54,7 +54,7 @@ author:
   family: Bohg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lin25c.md
+++ b/_posts/2025-10-07-lin25c.md
@@ -46,7 +46,7 @@ author:
   family: Zhu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lin25d.md
+++ b/_posts/2025-10-07-lin25d.md
@@ -55,7 +55,7 @@ author:
   family: Zheng
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25a.md
+++ b/_posts/2025-10-07-liu25a.md
@@ -39,7 +39,7 @@ author:
   family: Agarwal
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25b.md
+++ b/_posts/2025-10-07-liu25b.md
@@ -46,7 +46,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25c.md
+++ b/_posts/2025-10-07-liu25c.md
@@ -60,7 +60,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25d.md
+++ b/_posts/2025-10-07-liu25d.md
@@ -58,7 +58,7 @@ author:
   family: Zhu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25e.md
+++ b/_posts/2025-10-07-liu25e.md
@@ -61,7 +61,7 @@ author:
   family: Huiyong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25f.md
+++ b/_posts/2025-10-07-liu25f.md
@@ -45,7 +45,7 @@ author:
   family: Seita
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-liu25g.md
+++ b/_posts/2025-10-07-liu25g.md
@@ -43,7 +43,7 @@ author:
   family: Jia
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lorang25a.md
+++ b/_posts/2025-10-07-lorang25a.md
@@ -47,7 +47,7 @@ author:
   family: Scheutz
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-lum25a.md
+++ b/_posts/2025-10-07-lum25a.md
@@ -43,7 +43,7 @@ author:
   family: Bohg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-luo25a.md
+++ b/_posts/2025-10-07-luo25a.md
@@ -50,7 +50,7 @@ author:
   family: Pavone
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ma25a.md
+++ b/_posts/2025-10-07-ma25a.md
@@ -42,7 +42,7 @@ author:
   family: Muehlebach
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ma25b.md
+++ b/_posts/2025-10-07-ma25b.md
@@ -50,7 +50,7 @@ author:
   family: Liang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ma25c.md
+++ b/_posts/2025-10-07-ma25c.md
@@ -50,7 +50,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ma25d.md
+++ b/_posts/2025-10-07-ma25d.md
@@ -43,7 +43,7 @@ author:
   family: Sui
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-madan25a.md
+++ b/_posts/2025-10-07-madan25a.md
@@ -64,7 +64,7 @@ author:
   family: Bhattacharjee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-majumdar25a.md
+++ b/_posts/2025-10-07-majumdar25a.md
@@ -48,7 +48,7 @@ author:
   family: Sindhwani
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-mao25a.md
+++ b/_posts/2025-10-07-mao25a.md
@@ -46,7 +46,7 @@ author:
   family: Mistry
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-mao25b.md
+++ b/_posts/2025-10-07-mao25b.md
@@ -46,7 +46,7 @@ author:
   family: Kumar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-merwe25a.md
+++ b/_posts/2025-10-07-merwe25a.md
@@ -36,7 +36,7 @@ author:
   family: Jha
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-miandashti25a.md
+++ b/_posts/2025-10-07-miandashti25a.md
@@ -43,7 +43,7 @@ author:
   family: Brenner
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-munje25a.md
+++ b/_posts/2025-10-07-munje25a.md
@@ -59,7 +59,7 @@ author:
   family: Stone
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-noh25a.md
+++ b/_posts/2025-10-07-noh25a.md
@@ -49,7 +49,7 @@ author:
   family: Hong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-oishi25a.md
+++ b/_posts/2025-10-07-oishi25a.md
@@ -42,7 +42,7 @@ author:
   family: Tsuji
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-pan25a.md
+++ b/_posts/2025-10-07-pan25a.md
@@ -50,7 +50,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-parashar25a.md
+++ b/_posts/2025-10-07-parashar25a.md
@@ -41,7 +41,7 @@ author:
   family: Fan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-parimi25a.md
+++ b/_posts/2025-10-07-parimi25a.md
@@ -37,7 +37,7 @@ author:
   family: Williams
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-pasricha25a.md
+++ b/_posts/2025-10-07-pasricha25a.md
@@ -43,7 +43,7 @@ author:
   family: Roncone
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-peri25a.md
+++ b/_posts/2025-10-07-peri25a.md
@@ -41,7 +41,7 @@ author:
   family: Lee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-pfaff25a.md
+++ b/_posts/2025-10-07-pfaff25a.md
@@ -44,7 +44,7 @@ author:
   family: Tedrake
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-puthumanaillam25a.md
+++ b/_posts/2025-10-07-puthumanaillam25a.md
@@ -56,7 +56,7 @@ author:
   family: Ornik
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-qiu25a.md
+++ b/_posts/2025-10-07-qiu25a.md
@@ -65,7 +65,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-qiu25b.md
+++ b/_posts/2025-10-07-qiu25b.md
@@ -52,7 +52,7 @@ author:
   family: Gan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-rana25a.md
+++ b/_posts/2025-10-07-rana25a.md
@@ -50,7 +50,7 @@ author:
   family: Suenderhauf
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ravan25a.md
+++ b/_posts/2025-10-07-ravan25a.md
@@ -53,7 +53,7 @@ author:
   family: Yang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ravichandran25a.md
+++ b/_posts/2025-10-07-ravichandran25a.md
@@ -48,7 +48,7 @@ author:
   family: Kumar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-reuss25a.md
+++ b/_posts/2025-10-07-reuss25a.md
@@ -46,7 +46,7 @@ author:
   family: Lioutikov
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-rho25a.md
+++ b/_posts/2025-10-07-rho25a.md
@@ -42,7 +42,7 @@ author:
   family: Ha
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-rickenbach25a.md
+++ b/_posts/2025-10-07-rickenbach25a.md
@@ -47,7 +47,7 @@ author:
   family: Stork
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-rodriguez25a.md
+++ b/_posts/2025-10-07-rodriguez25a.md
@@ -41,7 +41,7 @@ author:
   family: Fazeli
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-rosasco25a.md
+++ b/_posts/2025-10-07-rosasco25a.md
@@ -50,7 +50,7 @@ author:
   family: Natale
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-saha25a.md
+++ b/_posts/2025-10-07-saha25a.md
@@ -49,7 +49,7 @@ author:
   family: Held
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-saxena25a.md
+++ b/_posts/2025-10-07-saxena25a.md
@@ -53,7 +53,7 @@ author:
   family: Kroemer
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-schmittle25a.md
+++ b/_posts/2025-10-07-schmittle25a.md
@@ -51,7 +51,7 @@ author:
   family: Srinivasa
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-schwarke25a.md
+++ b/_posts/2025-10-07-schwarke25a.md
@@ -47,7 +47,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-seneviratne25a.md
+++ b/_posts/2025-10-07-seneviratne25a.md
@@ -54,7 +54,7 @@ author:
   family: Manocha
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-seo25a.md
+++ b/_posts/2025-10-07-seo25a.md
@@ -43,7 +43,7 @@ author:
   family: Bajcsy
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sermanet25a.md
+++ b/_posts/2025-10-07-sermanet25a.md
@@ -42,7 +42,7 @@ author:
   family: Sindhwani
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-shah25a.md
+++ b/_posts/2025-10-07-shah25a.md
@@ -36,7 +36,7 @@ author:
   family: Srivastava
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sharma25a.md
+++ b/_posts/2025-10-07-sharma25a.md
@@ -60,7 +60,7 @@ author:
   family: Mukadam
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-shcherba25a.md
+++ b/_posts/2025-10-07-shcherba25a.md
@@ -44,7 +44,7 @@ author:
   family: Toussaint
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-shi25a.md
+++ b/_posts/2025-10-07-shi25a.md
@@ -45,7 +45,7 @@ author:
   family: Liu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-shorinwa25a.md
+++ b/_posts/2025-10-07-shorinwa25a.md
@@ -49,7 +49,7 @@ author:
   family: Majumdar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sobanbabu25a.md
+++ b/_posts/2025-10-07-sobanbabu25a.md
@@ -49,7 +49,7 @@ author:
   family: Shi
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sochopoulos25a.md
+++ b/_posts/2025-10-07-sochopoulos25a.md
@@ -45,7 +45,7 @@ author:
   family: Vijayakumar
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-spiridonov25a.md
+++ b/_posts/2025-10-07-spiridonov25a.md
@@ -42,7 +42,7 @@ author:
   family: Paudel
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sridhar25a.md
+++ b/_posts/2025-10-07-sridhar25a.md
@@ -49,7 +49,7 @@ author:
   family: Lee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-stamatopoulou25a.md
+++ b/_posts/2025-10-07-stamatopoulou25a.md
@@ -38,7 +38,7 @@ author:
   family: Kanoulas
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-su25a.md
+++ b/_posts/2025-10-07-su25a.md
@@ -60,7 +60,7 @@ author:
   family: Sreenath
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sun25a.md
+++ b/_posts/2025-10-07-sun25a.md
@@ -47,7 +47,7 @@ author:
   family: Walter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sun25b.md
+++ b/_posts/2025-10-07-sun25b.md
@@ -61,7 +61,7 @@ author:
   family: Li
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sun25c.md
+++ b/_posts/2025-10-07-sun25c.md
@@ -50,7 +50,7 @@ author:
   family: Yang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-sunil25a.md
+++ b/_posts/2025-10-07-sunil25a.md
@@ -49,7 +49,7 @@ author:
   family: Garcia
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tan25a.md
+++ b/_posts/2025-10-07-tan25a.md
@@ -67,7 +67,7 @@ author:
   family: Sartoretti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tang25a.md
+++ b/_posts/2025-10-07-tang25a.md
@@ -54,7 +54,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-thakkar25a.md
+++ b/_posts/2025-10-07-thakkar25a.md
@@ -67,7 +67,7 @@ author:
   family: Bhattacharjee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-thompson25a.md
+++ b/_posts/2025-10-07-thompson25a.md
@@ -45,7 +45,7 @@ author:
   family: Kuntz
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tian25a.md
+++ b/_posts/2025-10-07-tian25a.md
@@ -65,7 +65,7 @@ author:
   family: Matusik
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tian25b.md
+++ b/_posts/2025-10-07-tian25b.md
@@ -42,7 +42,7 @@ author:
   family: Kuo
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tian25c.md
+++ b/_posts/2025-10-07-tian25c.md
@@ -45,7 +45,7 @@ author:
   family: Su
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-tonkens25a.md
+++ b/_posts/2025-10-07-tonkens25a.md
@@ -49,7 +49,7 @@ author:
   family: Herbert
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-vijayan25a.md
+++ b/_posts/2025-10-07-vijayan25a.md
@@ -45,7 +45,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-villasevil25a.md
+++ b/_posts/2025-10-07-villasevil25a.md
@@ -50,7 +50,7 @@ author:
   family: Finn
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wagenmaker25a.md
+++ b/_posts/2025-10-07-wagenmaker25a.md
@@ -54,7 +54,7 @@ author:
   family: Levine
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wan25a.md
+++ b/_posts/2025-10-07-wan25a.md
@@ -45,7 +45,7 @@ author:
   family: Su
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25a.md
+++ b/_posts/2025-10-07-wang25a.md
@@ -58,7 +58,7 @@ author:
   family: Efros
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25b.md
+++ b/_posts/2025-10-07-wang25b.md
@@ -57,7 +57,7 @@ author:
   family: Liang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25c.md
+++ b/_posts/2025-10-07-wang25c.md
@@ -45,7 +45,7 @@ author:
   family: Garg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25d.md
+++ b/_posts/2025-10-07-wang25d.md
@@ -49,7 +49,7 @@ author:
   family: Sartoretti
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25e.md
+++ b/_posts/2025-10-07-wang25e.md
@@ -43,7 +43,7 @@ author:
   family: Erickson
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25f.md
+++ b/_posts/2025-10-07-wang25f.md
@@ -56,7 +56,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wang25g.md
+++ b/_posts/2025-10-07-wang25g.md
@@ -43,7 +43,7 @@ author:
   family: Yu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wegrzynowski25a.md
+++ b/_posts/2025-10-07-wegrzynowski25a.md
@@ -43,7 +43,7 @@ author:
   family: Walas
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wei25a.md
+++ b/_posts/2025-10-07-wei25a.md
@@ -45,7 +45,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wen25a.md
+++ b/_posts/2025-10-07-wen25a.md
@@ -42,7 +42,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wen25b.md
+++ b/_posts/2025-10-07-wen25b.md
@@ -52,7 +52,7 @@ author:
   family: Feng
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-werby25a.md
+++ b/_posts/2025-10-07-werby25a.md
@@ -47,7 +47,7 @@ author:
   family: Valada
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wilcox25a.md
+++ b/_posts/2025-10-07-wilcox25a.md
@@ -46,7 +46,7 @@ author:
   family: Garg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wistreich25a.md
+++ b/_posts/2025-10-07-wistreich25a.md
@@ -53,7 +53,7 @@ author:
   family: Wu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wu25a.md
+++ b/_posts/2025-10-07-wu25a.md
@@ -49,7 +49,7 @@ author:
   family: Bhattacharjee
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wu25b.md
+++ b/_posts/2025-10-07-wu25b.md
@@ -55,7 +55,7 @@ author:
   family: Yang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wu25c.md
+++ b/_posts/2025-10-07-wu25c.md
@@ -59,7 +59,7 @@ author:
   family: Yan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-wu25d.md
+++ b/_posts/2025-10-07-wu25d.md
@@ -58,7 +58,7 @@ author:
   family: Dong
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xie25a.md
+++ b/_posts/2025-10-07-xie25a.md
@@ -46,7 +46,7 @@ author:
   family: Hejna
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xing25a.md
+++ b/_posts/2025-10-07-xing25a.md
@@ -51,7 +51,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xiong25a.md
+++ b/_posts/2025-10-07-xiong25a.md
@@ -44,7 +44,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25a.md
+++ b/_posts/2025-10-07-xu25a.md
@@ -40,7 +40,7 @@ author:
   family: Hsu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25b.md
+++ b/_posts/2025-10-07-xu25b.md
@@ -46,7 +46,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25c.md
+++ b/_posts/2025-10-07-xu25c.md
@@ -47,7 +47,7 @@ author:
   family: Xu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25d.md
+++ b/_posts/2025-10-07-xu25d.md
@@ -52,7 +52,7 @@ author:
   family: Yang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25e.md
+++ b/_posts/2025-10-07-xu25e.md
@@ -43,7 +43,7 @@ author:
   family: Li
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25f.md
+++ b/_posts/2025-10-07-xu25f.md
@@ -50,7 +50,7 @@ author:
   family: Huang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-xu25g.md
+++ b/_posts/2025-10-07-xu25g.md
@@ -49,7 +49,7 @@ author:
   family: Narang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yamada25a.md
+++ b/_posts/2025-10-07-yamada25a.md
@@ -45,7 +45,7 @@ author:
   family: Posner
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yamada25b.md
+++ b/_posts/2025-10-07-yamada25b.md
@@ -48,7 +48,7 @@ author:
   family: Posner
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yan25a.md
+++ b/_posts/2025-10-07-yan25a.md
@@ -51,7 +51,7 @@ author:
   family: Fox
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yang25a.md
+++ b/_posts/2025-10-07-yang25a.md
@@ -50,7 +50,7 @@ author:
   family: Chen
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yang25b.md
+++ b/_posts/2025-10-07-yang25b.md
@@ -53,7 +53,7 @@ author:
   family: Bohg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yang25c.md
+++ b/_posts/2025-10-07-yang25c.md
@@ -48,7 +48,7 @@ author:
   family: Pajarinen
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yang25d.md
+++ b/_posts/2025-10-07-yang25d.md
@@ -51,7 +51,7 @@ author:
   family: Pathak
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yang25e.md
+++ b/_posts/2025-10-07-yang25e.md
@@ -43,7 +43,7 @@ author:
   family: Urtasun
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yao25a.md
+++ b/_posts/2025-10-07-yao25a.md
@@ -49,7 +49,7 @@ author:
   family: Li
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yi25a.md
+++ b/_posts/2025-10-07-yi25a.md
@@ -44,7 +44,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yin25a.md
+++ b/_posts/2025-10-07-yin25a.md
@@ -53,7 +53,7 @@ author:
   family: Lu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yin25b.md
+++ b/_posts/2025-10-07-yin25b.md
@@ -51,7 +51,7 @@ author:
   family: Zha
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yoo25a.md
+++ b/_posts/2025-10-07-yoo25a.md
@@ -44,7 +44,7 @@ author:
   family: Ichnowski
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yu25a.md
+++ b/_posts/2025-10-07-yu25a.md
@@ -55,7 +55,7 @@ author:
   family: Goldberg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-yuan25a.md
+++ b/_posts/2025-10-07-yuan25a.md
@@ -47,7 +47,7 @@ author:
   family: Qiu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-ze25a.md
+++ b/_posts/2025-10-07-ze25a.md
@@ -48,7 +48,7 @@ author:
   family: Liu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zeng25a.md
+++ b/_posts/2025-10-07-zeng25a.md
@@ -48,7 +48,7 @@ author:
   family: Sun
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25a.md
+++ b/_posts/2025-10-07-zhang25a.md
@@ -49,7 +49,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25b.md
+++ b/_posts/2025-10-07-zhang25b.md
@@ -58,7 +58,7 @@ author:
   family: Gao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25c.md
+++ b/_posts/2025-10-07-zhang25c.md
@@ -42,7 +42,7 @@ author:
   family: Hsu
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25d.md
+++ b/_posts/2025-10-07-zhang25d.md
@@ -41,7 +41,7 @@ author:
   family: Murphey
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25e.md
+++ b/_posts/2025-10-07-zhang25e.md
@@ -51,7 +51,7 @@ author:
   family: Gupta
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25f.md
+++ b/_posts/2025-10-07-zhang25f.md
@@ -44,7 +44,7 @@ author:
   family: Han
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25g.md
+++ b/_posts/2025-10-07-zhang25g.md
@@ -44,7 +44,7 @@ author:
   family: Zhang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25h.md
+++ b/_posts/2025-10-07-zhang25h.md
@@ -43,7 +43,7 @@ author:
   family: Song
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25i.md
+++ b/_posts/2025-10-07-zhang25i.md
@@ -52,7 +52,7 @@ author:
   family: Zhao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25j.md
+++ b/_posts/2025-10-07-zhang25j.md
@@ -45,7 +45,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25k.md
+++ b/_posts/2025-10-07-zhang25k.md
@@ -53,7 +53,7 @@ author:
   family: Zhao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25l.md
+++ b/_posts/2025-10-07-zhang25l.md
@@ -54,7 +54,7 @@ author:
   family: Gao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25m.md
+++ b/_posts/2025-10-07-zhang25m.md
@@ -41,7 +41,7 @@ author:
   family: Boularias
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhang25n.md
+++ b/_posts/2025-10-07-zhang25n.md
@@ -56,7 +56,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhao25a.md
+++ b/_posts/2025-10-07-zhao25a.md
@@ -49,7 +49,7 @@ author:
   family: Seita
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhao25b.md
+++ b/_posts/2025-10-07-zhao25b.md
@@ -54,7 +54,7 @@ author:
   family: Garg
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhao25c.md
+++ b/_posts/2025-10-07-zhao25c.md
@@ -61,7 +61,7 @@ author:
   family: Wang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhaxizhuoma25a.md
+++ b/_posts/2025-10-07-zhaxizhuoma25a.md
@@ -76,7 +76,7 @@ author:
   family: Li
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zheng25a.md
+++ b/_posts/2025-10-07-zheng25a.md
@@ -79,7 +79,7 @@ author:
   family: Fan
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhi25a.md
+++ b/_posts/2025-10-07-zhi25a.md
@@ -47,7 +47,7 @@ author:
   family: Huang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhou25a.md
+++ b/_posts/2025-10-07-zhou25a.md
@@ -50,7 +50,7 @@ author:
   family: Levine
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhu25a.md
+++ b/_posts/2025-10-07-zhu25a.md
@@ -50,7 +50,7 @@ author:
   family: Fang
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhu25b.md
+++ b/_posts/2025-10-07-zhu25b.md
@@ -43,7 +43,7 @@ author:
   family: Oh
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhuang25a.md
+++ b/_posts/2025-10-07-zhuang25a.md
@@ -45,7 +45,7 @@ author:
   family: Kragic
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zhuang25b.md
+++ b/_posts/2025-10-07-zhuang25b.md
@@ -39,7 +39,7 @@ author:
   family: Zhao
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/_posts/2025-10-07-zurbrugg25a.md
+++ b/_posts/2025-10-07-zurbrugg25a.md
@@ -45,7 +45,7 @@ author:
   family: Hutter
 date: 2025-10-07
 address:
-container-title: Proceedings of The 8th Conference on Robot Learning
+container-title: Proceedings of The 9th Conference on Robot Learning
 volume: '305'
 genre: inproceedings
 issued:

--- a/corl25.bib
+++ b/corl25.bib
@@ -1,5 +1,5 @@
 @Proceedings{CoRL-2025,
-	booktitle = {Proceedings of The 8th Conference on Robot Learning},
+	booktitle = {Proceedings of The 9th Conference on Robot Learning},
 	name = {Conference on Robot Learning},
 	shortname = {CoRL},
 	year = {2025},

--- a/corl25_clean.bib
+++ b/corl25_clean.bib
@@ -1,5 +1,5 @@
 @Proceedings{CoRL-2025,
-	booktitle = {Proceedings of The 8th Conference on Robot Learning},
+	booktitle = {Proceedings of The 9th Conference on Robot Learning},
 	name = {Conference on Robot Learning},
 	shortname = {CoRL},
 	year = {2025},


### PR DESCRIPTION
# Paper Edit Request

## Your Role
- [ ] I am an author of this paper
- [ ] I am acting on behalf of an author
- [ ] I am an editor of this volume
- [ ] I am acting on behalf of an editor
- [x] Other (please describe): I am one of the authors of a paper in this volume

## Nature of Changes
- [x] Minor edit to meta information (typo, formatting, etc.)
- [ ] PDF change (requires proceedings editor permission)
- [ ] Content change (requires proceedings editor permission)

## Description of Changes
Fix the typo of the conference number in the published proceedings, which doesn't match the actual conference number of **CoRL 2025 (9th Annual Conference on Robot Learning)**.

## Additional Notes
CoRL 2025 on OpenReview (which shows **9th Annual Conference on Robot Learning**):
https://openreview.net/group?id=robot-learning.org/CoRL/2025/Conference